### PR TITLE
Fix setting min/max absolute values via IB (#1).

### DIFF
--- a/JFADoubleSlider/JFADoubleSlider.m
+++ b/JFADoubleSlider/JFADoubleSlider.m
@@ -68,7 +68,7 @@ static const int PRECISION = 1;
 
 - (void)setAbsMaxVal:(float)absMaxVal
 {
-    if (absMaxVal > _curMaxVal)
+    if (!_doneSettingUp || absMaxVal > _curMaxVal)
     {
         _absMaxVal = absMaxVal;
         [self setNeedsDisplay];
@@ -247,7 +247,7 @@ static const int PRECISION = 1;
 
 - (void)setAbsMinVal:(float)absMinVal
 {
-    if (absMinVal < _curMinVal)
+    if (!_doneSettingUp || absMinVal < _curMinVal)
     {
         _absMinVal = absMinVal;
         [self setNeedsDisplay];


### PR DESCRIPTION
In the setters for the absMinVal and absMaxVal properties,
check if the control is done setting up and if it is not, allow
the value to be set.
- Use _isDoneSettingUp to check if the value can be set.
