### PR TITLE
Expose delegate with IBOutlet to IB (fix #3).

### DIFF
--- a/JFADoubleSlider/JFADoubleSlider.h
+++ b/JFADoubleSlider/JFADoubleSlider.h
@@ -32,7 +32,7 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL reportInteger; // display and report knob values as ints
 @property (nonatomic) IBInspectable BOOL showValues; // show knob values below knobs
 @property (nonatomic, getter=isContinuous) IBInspectable BOOL continuous; // report new knob values as they change
-@property (weak, nonatomic) id<JFADoubleSliderDelegate> delegate; // see JFADoubleSliderDelegate comment
+@property (weak, nonatomic) IBOutlet id<JFADoubleSliderDelegate> delegate; // see JFADoubleSliderDelegate comment
 - (void)setCurMaxVal:(float)curMaxVal animated:(BOOL)animated; // set right knob value, possiby animating
 - (void)setCurMinVal:(float)curMinVal animated:(BOOL)animated; // set left knob value, possibly animating
 @end


### PR DESCRIPTION
This fixes issue #3 where the delegate defined in the header is not available via the Connections panel in Interface Builder.
- Use IBOutlet to allow for Connections panel to see delegate in Interface Builder.
