### PR TITLE
Fix issue #5 for compilation warnings.

### DIFF
--- a/JFADoubleSlider/JFADoubleSlider.m
+++ b/JFADoubleSlider/JFADoubleSlider.m
@@ -375,8 +375,8 @@ static const int PRECISION = 1;
         CGFloat firstX = ((self.curMinVal - self.absMinVal) / virtualWidth) * adjustedBoundsWidth + KNOB_WIDTH / 2;
         CGFloat secondX = ((self.curMaxVal - self.absMinVal) / virtualWidth) * adjustedBoundsWidth + KNOB_WIDTH / 2;
         CGFloat gestureX = [gesture locationInView:self].x;
-        float distFirst = fabsf(gestureX - firstX);
-        float distSecond = fabsf(gestureX - secondX);
+        float distFirst = ABS(gestureX - firstX);
+        float distSecond = ABS(gestureX - secondX);
         if (distFirst < distSecond)
         {
             self.currentKnob = LEFT_KNOB;


### PR DESCRIPTION
Due to iOS now supporting 64bit and 32bit, CGFloat is defined as a `double` for 64bit and `float` for 32bit. The `ABS` macro is made available to get the absolute value and is type agnostic. This will work on 64bit and 32bit now without any compilation warnings.
- Use the ABS macro instead of fabsf.
