### PR TITLE
Create initial Cocoapods podspec.

### DIFF
--- a/JFADoubleSlider.podspec
+++ b/JFADoubleSlider.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name             = "JFADoubleSlider"
+  s.version          = "1.0.0"
+  s.summary          = "A custom control, inspired by UISlider, for selecting a range of values."
+  s.homepage         = "https://github.com/vermont42/JFADoubleSlider"
+  s.license          = "MIT"
+  s.author           = "Josh Adams"
+  s.source           = { :git => "https://github.com/vermont42/JFADoubleSlider.git", :tag => s.version.to_s }
+  s.social_media_url = "https://twitter.com/vermont42"
+  s.source_files     = "JFADoubleSlider/JFADoubleSlider.h", "JFADoubleSlider/JFADoubleSlider.m"
+  s.platform         = :ios, "8.0"
+  s.requires_arc     = true
+end


### PR DESCRIPTION
This is the initial Cocoapod podspec.

I did not publish the Cocoapod but I did test it with `pod lib lint`.

I followed the official [Cocoapods Guide](https://guides.cocoapods.org/making/making-a-cocoapod.html) to create the Podspec. I assumed the versions will be tagged as `1.0.0`, `1.0.2`, etc.

**NOTE: Issue #5 should be resolved and merged before finishing this as the `pod lib lint` will not pass due to the warnings.**
